### PR TITLE
Amplify the night sky glow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
-# sky-full-of-stars
+# Sky Full of Stars
+
+A lightweight React-powered love note page that sparkles like a midnight sky. Each message floats beneath a divider of blinking stars, and the final note rests under a glowing full moon. Edit the `loveNotes` array in `app.jsx` to adjust how many messages brighten the sky.
+
+## Getting started
+
+1. Open `index.html` in your favourite browser.
+2. Update the `loveNotes` array inside `app.jsx` whenever you want to add, remove, or change a message.
+
+Because the page relies on CDN-hosted React and Babel builds, you do not need to install or build anything—just refresh the page after editing the files.

--- a/app.jsx
+++ b/app.jsx
@@ -1,0 +1,126 @@
+const loveNotes = [
+  "In the quiet of the night, I always find myself wishing on the stars for more time with you.",
+  "Every twinkle above us reminds me of how your smile lights up my world.",
+  "No constellation could ever compare to the map of love I trace whenever I hold your hand.",
+  "My heart glows brightest when it’s orbiting around you—forever and always."
+];
+
+const createStarField = (count) =>
+  Array.from({ length: count }, (_, index) => ({
+    id: index,
+    top: `${Math.random() * 100}%`,
+    left: `${Math.random() * 100}%`,
+    size: `${Math.random() * 2.8 + 1.8}px`,
+    duration: `${2 + Math.random() * 4}s`,
+    delay: `${Math.random() * 4}s`,
+    opacity: Math.random() * 0.25 + 0.75,
+  }));
+
+const starField = createStarField(220);
+
+const StarField = () => (
+  <div className="star-field" aria-hidden="true">
+    {starField.map((star) => (
+      <span
+        key={star.id}
+        className="star"
+        style={{
+          top: star.top,
+          left: star.left,
+          width: star.size,
+          height: star.size,
+          animationDuration: star.duration,
+          animationDelay: star.delay,
+          opacity: star.opacity,
+        }}
+      />
+    ))}
+  </div>
+);
+
+const StarDivider = ({ isLast }) => {
+  const stars = React.useMemo(
+    () =>
+      Array.from({ length: 75 }, (_, index) => ({
+        id: index,
+        top: `${Math.random() * 100}%`,
+        left: `${Math.random() * 100}%`,
+        size: `${Math.random() * 2.4 + 1.6}px`,
+        duration: `${2.2 + Math.random() * 3.3}s`,
+        delay: `${Math.random() * 4}s`,
+        opacity: Math.random() * 0.2 + 0.8,
+      })),
+    []
+  );
+
+  if (isLast) {
+    return (
+      <div className="moon-wrapper" aria-hidden="true">
+        <span className="moon-halo" />
+        <img
+          className="moon-svg"
+          src="https://www.svgrepo.com/show/401844/full-moon.svg"
+          alt="Full moon"
+          loading="lazy"
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="star-spray" aria-hidden="true">
+      {stars.map((star) => (
+        <span
+          key={star.id}
+          className="spray-star"
+          style={{
+            top: star.top,
+            left: star.left,
+            width: star.size,
+            height: star.size,
+            animationDuration: star.duration,
+            animationDelay: star.delay,
+            opacity: star.opacity,
+          }}
+        />
+      ))}
+    </div>
+  );
+};
+
+const MessageSection = ({ text, isLast }) => (
+  <section className="message-section">
+    <StarDivider isLast={isLast} />
+    <p className="glowing-text">{text}</p>
+  </section>
+);
+
+const App = () => (
+  <main className="night-sky">
+    <StarField />
+    <div className="sky-overlay" aria-hidden="true" />
+
+    <div className="content">
+      <header className="intro">
+        <h1>For My Brightest Star</h1>
+        <p className="intro-text">
+          These words drift across our own little universe—each one shining just for you.
+          Tweak the messages array to fill the sky with as many whispers of love as you like.
+        </p>
+      </header>
+
+      <div className="messages">
+        {loveNotes.map((note, index) => (
+          <MessageSection
+            key={note.slice(0, 10) + index}
+            text={note}
+            isLast={index === loveNotes.length - 1}
+          />
+        ))}
+      </div>
+    </div>
+  </main>
+);
+
+const root = ReactDOM.createRoot(document.getElementById("root"));
+root.render(<App />);

--- a/index.html
+++ b/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sky Full of Stars</title>
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600&family=Pacifico&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="./styles.css" />
+    <script src="https://unpkg.com/react@18/umd/react.production.min.js" crossorigin></script>
+    <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js" crossorigin></script>
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="text/babel" src="./app.jsx"></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,263 @@
+:root {
+  color-scheme: dark;
+  --sky-top: #05071a;
+  --sky-middle: #08102f;
+  --sky-bottom: #03040d;
+  --starlight: #f4e6ff;
+  --starlight-soft: rgba(244, 230, 255, 0.6);
+  --moonlight: #fef9d7;
+  --moon-shadow: rgba(255, 249, 215, 0.4);
+  --card-bg: rgba(10, 13, 31, 0.55);
+  --card-border: rgba(255, 255, 255, 0.12);
+  --card-shadow: rgba(83, 127, 255, 0.25);
+  --glow-primary: rgba(157, 207, 255, 0.55);
+  --glow-secondary: rgba(255, 185, 248, 0.45);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: "Poppins", "Segoe UI", system-ui, -apple-system, sans-serif;
+  background: radial-gradient(circle at 10% 20%, #081436 0%, #05071a 55%, #02030b 100%);
+  color: var(--starlight);
+  overflow-x: hidden;
+}
+
+.night-sky {
+  position: relative;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6rem 1.5rem 7rem;
+  overflow: hidden;
+}
+
+.sky-overlay {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(circle at 20% 20%, rgba(107, 141, 255, 0.2), transparent 45%),
+    radial-gradient(circle at 80% 15%, rgba(255, 167, 234, 0.2), transparent 40%),
+    radial-gradient(circle at 50% 75%, rgba(255, 225, 155, 0.1), transparent 35%);
+  mix-blend-mode: screen;
+  z-index: 0;
+}
+
+.content {
+  position: relative;
+  z-index: 1;
+  width: min(960px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 4rem;
+}
+
+.intro {
+  text-align: center;
+  display: grid;
+  gap: 1.25rem;
+  padding: 2.5rem 1.5rem 2rem;
+  border-radius: 24px;
+  background: linear-gradient(145deg, rgba(13, 17, 45, 0.8), rgba(4, 7, 26, 0.65));
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 25px 70px -30px rgba(61, 117, 255, 0.45), inset 0 0 40px rgba(80, 139, 255, 0.18);
+  backdrop-filter: blur(18px);
+}
+
+.intro h1 {
+  margin: 0;
+  font-family: "Pacifico", "Poppins", sans-serif;
+  font-size: clamp(2.4rem, 2.6rem + 1vw, 3.4rem);
+  letter-spacing: 2px;
+  color: #fff;
+  text-shadow: 0 0 8px rgba(255, 255, 255, 0.9), 0 0 18px rgba(108, 198, 255, 0.7);
+}
+
+.intro-text {
+  margin: 0;
+  font-size: clamp(1rem, 0.95rem + 0.4vw, 1.2rem);
+  line-height: 1.7;
+  color: rgba(239, 241, 255, 0.88);
+  text-shadow: 0 0 10px rgba(93, 143, 255, 0.5);
+}
+
+.star-field {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  overflow: hidden;
+  pointer-events: none;
+}
+
+.star {
+  position: absolute;
+  background: radial-gradient(circle, rgba(255, 255, 255, 0.98) 0%, rgba(255, 255, 255, 0.78) 45%, rgba(156, 193, 255, 0.65) 70%, transparent 100%);
+  border-radius: 50%;
+  box-shadow: 0 0 18px 4px rgba(128, 176, 255, 0.5);
+  animation-name: twinkle;
+  animation-timing-function: ease-in-out;
+  animation-iteration-count: infinite;
+}
+
+@keyframes twinkle {
+  0%,
+  100% {
+    transform: scale(0.95);
+    opacity: 0.65;
+  }
+  50% {
+    transform: scale(1.25);
+    opacity: 1;
+  }
+}
+
+.messages {
+  display: grid;
+  gap: clamp(3.5rem, 3rem + 1.8vw, 5rem);
+}
+
+.message-section {
+  position: relative;
+  display: grid;
+  justify-items: center;
+  gap: clamp(1.5rem, 1.2rem + 1vw, 2.2rem);
+  padding: 0 clamp(1.25rem, 1.1rem + 2vw, 3.25rem);
+}
+
+.star-spray {
+  position: relative;
+  width: 100%;
+  height: clamp(140px, 22vw, 200px);
+  margin-bottom: 0.5rem;
+  pointer-events: none;
+}
+
+.spray-star {
+  position: absolute;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(255, 255, 255, 0.98) 0%, rgba(255, 255, 255, 0.82) 45%, rgba(167, 206, 255, 0.65) 70%, transparent 100%);
+  box-shadow: 0 0 22px 6px rgba(158, 198, 255, 0.45);
+  animation-name: sprayTwinkle;
+  animation-timing-function: ease-in-out;
+  animation-iteration-count: infinite;
+}
+
+@keyframes sprayTwinkle {
+  0%,
+  100% {
+    transform: scale(1);
+    opacity: 0.9;
+  }
+  50% {
+    transform: scale(1.4);
+    opacity: 1;
+  }
+}
+
+.moon-wrapper {
+  position: relative;
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  padding-bottom: 0.5rem;
+}
+
+.moon-wrapper .moon-halo {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) scale(0.9);
+  width: clamp(160px, 28vw, 220px);
+  aspect-ratio: 1 / 1;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(255, 243, 196, 0.55) 0%, transparent 65%);
+  filter: blur(18px);
+  animation: haloPulse 7s ease-in-out infinite;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.moon-svg {
+  position: relative;
+  width: clamp(110px, 18vw, 160px);
+  filter: drop-shadow(0 0 22px rgba(255, 245, 205, 0.6)) drop-shadow(0 0 36px rgba(255, 245, 205, 0.45));
+  animation: moonGlow 6s ease-in-out infinite;
+  z-index: 1;
+}
+
+@keyframes moonGlow {
+  0%,
+  100% {
+    transform: scale(1);
+    filter: drop-shadow(0 0 22px rgba(255, 245, 205, 0.6))
+      drop-shadow(0 0 36px rgba(255, 245, 205, 0.45));
+  }
+  50% {
+    transform: scale(1.02);
+    filter: drop-shadow(0 0 28px rgba(255, 245, 205, 0.75))
+      drop-shadow(0 0 44px rgba(255, 245, 205, 0.55));
+  }
+}
+
+@keyframes haloPulse {
+  0%,
+  100% {
+    opacity: 0.55;
+    transform: translate(-50%, -50%) scale(0.9);
+  }
+  50% {
+    opacity: 0.95;
+    transform: translate(-50%, -50%) scale(1);
+  }
+}
+
+.glowing-text {
+  margin: 0;
+  font-size: clamp(1.3rem, 1.1rem + 0.9vw, 1.8rem);
+  line-height: 1.8;
+  text-align: center;
+  color: #ffffff;
+  letter-spacing: 0.015em;
+  text-shadow: 0 0 8px rgba(255, 255, 255, 0.6), 0 0 16px var(--glow-primary), 0 0 26px var(--glow-secondary);
+}
+
+@media (max-width: 768px) {
+  .night-sky {
+    padding: 4rem 1.25rem 5rem;
+  }
+
+  .content {
+    gap: 3rem;
+  }
+
+  .message-section {
+    gap: 1.5rem;
+  }
+
+  .star-spray {
+    height: clamp(110px, 38vw, 170px);
+  }
+}
+
+@media (max-width: 520px) {
+  .intro {
+    padding: 2rem 1.25rem 1.75rem;
+  }
+
+  .messages {
+    gap: 3rem;
+  }
+
+  .glowing-text {
+    font-size: 1.2rem;
+  }
+
+  .star-spray {
+    height: clamp(100px, 45vw, 150px);
+  }
+}


### PR DESCRIPTION
## Summary
- increase the starfield density and brightness so the background twinkles read more clearly
- boost the separator spray size, opacity, and glow for a more visible divider between notes
- keep the finale moon SVG while intensifying surrounding halo animations for a brighter finish

## Testing
- not run (static content)

------
https://chatgpt.com/codex/tasks/task_e_68e3f6ce84cc8326b16e5d4f7137dd16